### PR TITLE
fix druid filter init bug

### DIFF
--- a/dynamic-datasource-creator/src/main/java/com/baomidou/dynamic/datasource/creator/druid/DruidConfigUtil.java
+++ b/dynamic-datasource-creator/src/main/java/com/baomidou/dynamic/datasource/creator/druid/DruidConfigUtil.java
@@ -81,7 +81,7 @@ public final class DruidConfigUtil {
         }
 
         //filters单独处理，默认了stat
-        String filters = getValue(g, c, "filter");
+        String filters = getValue(g, c, "filters");
         if (filters == null) {
             filters = STAT_STR;
         }


### PR DESCRIPTION
filter->filters

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style
- [ ] Refactor
- [ ] Doc
- [ ] Other, please describe:

**The description of the PR:**
druid的拦截器名称配置属性是filters而不是filter，反射的时候是获取不到值的。

DruidConfig.java 
private String filters;

**Other information:**



